### PR TITLE
Updated to support jQuery 3

### DIFF
--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -317,7 +317,7 @@
 				});
 
 				// attach event on entire page load, maybe some images inside element has been loading, so chek height again
-				$window.load(function(){
+				$(function(){
 					if ($this.outerHeight(true) > $container.height()) {
 						$wrapper.css('height', $this.outerHeight(true));
 						$this.hcSticky('reinit');


### PR DESCRIPTION
Removed use of deprecated `$.load` method.
